### PR TITLE
skip extconf.rb on jruby

### DIFF
--- a/ext/faye_websocket_mask/extconf.rb
+++ b/ext/faye_websocket_mask/extconf.rb
@@ -1,6 +1,6 @@
-require 'mkmf'
+return if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 
+require 'mkmf'
 extension_name = 'faye_websocket_mask'
 dir_config(extension_name)
 create_makefile(extension_name)
-


### PR DESCRIPTION
I'm still having trouble with faye-websocket on Travis:

http://travis-ci.org/#!/jonleighton/poltergeist/jobs/838917

It is due to the `require 'mkmf'` in extconf.rb.

As far as I can tell you are just shipping a jar file with the gem, so extconf.rb is irrelevant to JRuby.

Therefore I am just returning from this file if JRuby is detected.

Please push a new gem if you're happy with this :)

Cheers
