### PR TITLE
Support IE10

### DIFF
--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -94,7 +94,7 @@ module Faye
       env['REQUEST_METHOD'] == 'GET' and
       env['HTTP_CONNECTION'] and
       env['HTTP_CONNECTION'].split(/\s*,\s*/).include?('Upgrade') and
-      ['WebSocket', 'websocket'].include?(env['HTTP_UPGRADE'])
+      env['HTTP_UPGRADE'].downcase == "websocket"
     end
     
     def self.parser(env)


### PR DESCRIPTION
IE 10 sends `Websocket` and the code was looking for `websocket` or `WebSocket`. Added support for `Websocket`.
