### PR TITLE
Compatibility with Rainbows! 4.5.0

### DIFF
--- a/lib/faye/adapters/rainbows_client.rb
+++ b/lib/faye/adapters/rainbows_client.rb
@@ -61,7 +61,12 @@ module Faye
       end
 
       def write_headers(status, headers, *args)
-        super unless socket_connection? and status == 101
+        if socket_connection? and status == 101
+          _, body = args
+          body
+        else
+          super
+        end
       end
     end
 


### PR DESCRIPTION
Rainbows! 4.5.0 modifies the signature of the Rainbows::Response#write_headers method which now specifies that the fourth argument (body) is returned unless the connection has been hijacked via Rack hijacking functionality, in which case it should return nil.  This commit updates the Faye::WebSocket::RainbowsClient implementation to conform to this new specification.
