### PR TITLE
Fixes crash when the Upgrade header isn't present.

### DIFF
--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -94,6 +94,7 @@ module Faye
       env['REQUEST_METHOD'] == 'GET' and
       env['HTTP_CONNECTION'] and
       env['HTTP_CONNECTION'].downcase.split(/\s*,\s*/).include?('upgrade') and
+      env['HTTP_UPGRADE'] and
       env['HTTP_UPGRADE'].downcase == 'websocket'
     end
 


### PR DESCRIPTION
Due to the fix in #15 (I guess), the server crashes when a browser goes to /faye/:

```
/home/jenkins/.bundler/ruby/1.9.1/faye-websocket-ruby-1ac1bf27a9e8/lib/faye/websocket.rb:97:in `websocket?': undefined method `downcase' for nil:NilClass (NoMethodError)
    from /home/jenkins/.bundler/ruby/1.9.1/faye-websocket-ruby-1ac1bf27a9e8/lib/faye/websocket/adapter.rb:7:in `websocket?'
    from /home/jenkins/.bundler/ruby/1.9.1/faye-websocket-ruby-1ac1bf27a9e8/lib/faye/adapters/thin.rb:33:in `process'
    from /var/lib/gems/1.9.1/gems/thin-1.5.1/lib/thin/connection.rb:39:in `receive_data'
    from /home/jenkins/.bundler/ruby/1.9.1/faye-websocket-ruby-1ac1bf27a9e8/lib/faye/adapters/thin.rb:45:in `receive_data'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
    from /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
    from /var/lib/gems/1.9.1/gems/thin-1.5.1/lib/thin/backends/base.rb:63:in `start'
    from /var/lib/gems/1.9.1/gems/thin-1.5.1/lib/thin/server.rb:159:in `start'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/handler/thin.rb:16:in `run'
    from /var/lib/gems/1.9.1/gems/faye-0.8.9/lib/faye/adapters/rack_adapter.rb:54:in `listen'
    from /home/jenkins/workspace/console-sgc/faye/config.ru:12:in `block in <main>'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:55:in `instance_eval'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:55:in `initialize'
    from /home/jenkins/workspace/console-sgc/faye/config.ru:in `new'
    from /home/jenkins/workspace/console-sgc/faye/config.ru:in `<main>'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:49:in `eval'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:49:in `new_from_string'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:40:in `parse_file'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:277:in `build_app_and_options_from_config'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:199:in `app'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:314:in `wrapped_app'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:250:in `start'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
    from /var/lib/gems/1.9.1/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
    from /usr/local/bin/rackup:23:in `load'
    from /usr/local/bin/rackup:23:in `<main>'
```

Here's a small fix :)
