### PR TITLE
Add adapter to improve Passenger performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,13 @@ Apache doesn't work well with WebSockets at this time. You do not need any
 special configuration to make faye-websocket work, it should work out of the box
 on Passenger provided you use at least Passenger 4.0.
 
+If you use Passenger to serve your application you need to include this line after
+loading `faye/passenger` for optimal performance:
+
+```ruby
+Faye::WebSocket.load_adapter('passenger')
+```
+
 Run your app on Passenger for Nginx by creating a virtual host entry which
 points to your app's "public" directory:
 

--- a/examples/config.ru
+++ b/examples/config.ru
@@ -9,5 +9,6 @@ require File.expand_path('../app', __FILE__)
 
 Faye::WebSocket.load_adapter('thin')
 Faye::WebSocket.load_adapter('rainbows')
+Faye::WebSocket.load_adapter('passenger')
 
 run App

--- a/lib/faye/adapters/passenger.rb
+++ b/lib/faye/adapters/passenger.rb
@@ -1,0 +1,3 @@
+if defined?(PhusionPassenger)
+  PhusionPassenger.advertised_concurrency_level = 0
+end

--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -23,6 +23,7 @@ module Faye
 
     ADAPTERS = {
       'goliath'  => :Goliath,
+      'passenger'  => :PhusionPassenger,
       'rainbows' => :Rainbows,
       'thin'     => :Thin
     }


### PR DESCRIPTION
Hi, 

if you don't override Passenger's advertised_concurrency value to be infinity, it will limit the amount of sessions per process to 1. This forces users to have a process per websocket connection (expensive) or to buy Phusion Passenger Enterprise and use a thread per websocket connection (slightly less expensive), both options bypass the cool performance boost EM based solutions should normally have.

When the app advertises infinite concurrency, you get all the benefits and can easily do thousands of websocket connections to a single process. I verified these patches by running npm's thor websocket stresser against the `passenger -start -R examples/config.ru`. 

Without adapter:
```
Durations (ms):

                     min     mean     stddev  median max    
Handshaking          9       177          87     179 328    
Latency              0       2             3       1 37     

Percentile (ms):

                      50%     66%     75%     80%     90%     95%     98%     98%    100%   
Handshaking          179     230     249     261     280     308     321     328     328    
Latency              1       2       3       3       5       6       10      12      37 
```

With adapter:
```
Durations (ms):

                     min     mean     stddev  median max    
Handshaking          10      41           19      41 91     
Latency              0       23           15      20 85     

Percentile (ms):

                      50%     66%     75%     80%     90%     95%     98%     98%    100%   
Handshaking          41      55      58      60      64      71      79      91      91     
Latency              20      24      31      33      44      53      72      77      85
```

The benchmarker isn't really well suited for benchmarking concurrency unfortunately, but you can see in the long max-duration that some sessions were held up for almost as long as the entire test ran. This doesn't happen with the concurrency enabled.