### PR TITLE
Set required_ruby_version in gemspec

### DIFF
--- a/faye-websocket.gemspec
+++ b/faye-websocket.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.email             = 'jcoglan@gmail.com'
   s.homepage          = 'http://github.com/faye/faye-websocket-ruby'
   s.license           = 'MIT'
+  s.required_ruby_version = ">= 1.9.3"
 
   s.extra_rdoc_files  = %w[README.md]
   s.rdoc_options      = %w[--main README.md --markup markdown]


### PR DESCRIPTION
I've confirmed that faye-websocket does not work on ruby 1.8.7.
It may work on ruby 1.9.2, but if you are only testing on ruby
1.9.3+, it's probably best to use that.