### PR TITLE
Make sure EM.attach is called on the reactor thread

### DIFF
--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -74,11 +74,16 @@ module Faye
       if callback = @env['async.callback']
         callback.call([101, {}, @stream])
       end
+    end
 
-      @driver.start
+    def start_driver
+      return if @driver.nil? || @driver_started
+      @driver_started = true
+      EventMachine.schedule { @driver.start }
     end
 
     def rack_response
+      start_driver
       [ -1, {}, [] ]
     end
 


### PR DESCRIPTION
While running Faye with Puma under heavy stress testing, we were experiencing crashes with `std::runtime_error: adding existing descriptor` in the logs. Reading up on that problem brought us to [this](https://github.com/eventmachine/eventmachine/issues/354) EventMachine issue, where the developer states that `EM.attach` should only be called on the reactor thread.

This pull uses `EM.schedule` as recommended to make sure the `EM.attach` call happens immediately if already on the reactor thread, or is scheduled for the next tick if not (in a Puma IO thread, for example), which seems to have cleared up the issue for us. 

I also added a check to see if the stream was closed before the next tick is processed (which would mean `@rack_hijack_io` is nil) to make sure that things are cleaned up properly in that case. It could be that I'm being too paranoid and that isn't needed, though.

This should resolve [issues](https://github.com/faye/faye-websocket-ruby/issues/35) users were seeing with other non EventMachine based servers as well, such as Rainbows with epoll or a threadpool. 

Please let me know what you think.