### PR TITLE
Fix use of the non-standard, deprecated, REQUEST_URI

### DIFF
--- a/lib/faye/eventsource.rb
+++ b/lib/faye/eventsource.rb
@@ -16,7 +16,7 @@ module Faye
 
     def self.determine_url(env)
       scheme = WebSocket.secure_request?(env) ? 'https:' : 'http:'
-      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].eampty? ? '' : "?#{env['QUERY_STRING']}"}"
+      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].empty? ? '' : "?#{env['QUERY_STRING']}"}"
     end
 
     def initialize(env, options = {})

--- a/lib/faye/eventsource.rb
+++ b/lib/faye/eventsource.rb
@@ -16,7 +16,7 @@ module Faye
 
     def self.determine_url(env)
       scheme = WebSocket.secure_request?(env) ? 'https:' : 'http:'
-      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['REQUEST_URI'] }"
+      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].eampty? ? '' : "?#{env['QUERY_STRING']}"}"
     end
 
     def initialize(env, options = {})

--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -29,7 +29,7 @@ module Faye
 
     def self.determine_url(env)
       scheme = secure_request?(env) ? 'wss:' : 'ws:'
-      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].eampty? ? '' : "?#{env['QUERY_STRING']}"}"
+      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].empty? ? '' : "?#{env['QUERY_STRING']}"}"
     end
 
     def self.ensure_reactor_running

--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -29,7 +29,7 @@ module Faye
 
     def self.determine_url(env)
       scheme = secure_request?(env) ? 'wss:' : 'ws:'
-      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['REQUEST_URI'] }"
+      "#{ scheme }//#{ env['HTTP_HOST'] }#{ env['PATH_INFO'] }#{env['QUERY_STRING'].eampty? ? '' : "?#{env['QUERY_STRING']}"}"
     end
 
     def self.ensure_reactor_running


### PR DESCRIPTION
REQUEST_URI is NOT part of the [Rack standard](http://www.rubydoc.info/github/rack/rack/file/SPEC), as pointed to [here](brynary/rack-test#26).

REQUEST_URI was last in use while Rails 2 was still the way to go... Rack 1.3 defines PATH_INFO and QUERY_STRING only.

Using REQUEST_URI means that another copy of these string must be created (a variation).

Also, PATH_INFO holds only the path (which is probably what we want here, but I preserved the query data just because I'm a visitor to these foreign lands), while REQUEST_URI was historically used to hold both the path and the query info.
