### PR TITLE
Adds client - tls documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ is an optional hash containing any of these keys:
   The default value is `2^26 - 1`, or 1 byte short of 64 MiB.
 * `:ping` - an integer that sets how often the WebSocket should send ping
   frames, measured in seconds
-
+* `:tls` - a hash containing key-value pairs for specifying TLS parameters.
+  These are passed along to EventMachine and you can find
+  [more details here](http://rubydoc.info/gems/eventmachine/EventMachine%2FConnection%3Astart_tls)
 
 ## WebSocket API
 


### PR DESCRIPTION
I was in the situation where I wanted to specify the private key and
chain file for the client. But this information was missing from
the README. For example:

    opts = {
      tls: {
        cert_chain_file: 'cert.pem',
        private_key_file: 'key.pem',
        verify_peer: false
      }
    }

    ws = Faye::WebSocket::Client.new(wss_endpoint, [], opts)

If you have any questions or if you're not happy with the wording,
let me know.

Cheers and thanks for the library!