### PR TITLE
Handle reactor stopping during rack hijack

### DIFF
--- a/spec/faye/websocket_spec.rb
+++ b/spec/faye/websocket_spec.rb
@@ -2,48 +2,55 @@ require "spec_helper"
 require "socket"
 
 describe Faye::WebSocket do
-  it "can start the reactor" do
-    expect(EventMachine.reactor_running?).to be(false)
+  context "using the RackStream driver" do
+    it "can start the reactor" do
+      rack_hijack_proc = ->() {}
+      expect(rack_hijack_proc).to receive(:call)
 
-    env = Rack::MockRequest.env_for(
-      "/",
-      "HTTP_HOST" => "localhost",
-      "HTTP_CONNECTION" => "Upgrade",
-      "HTTP_UPGRADE" => "websocket"
-    )
-    ws = Faye::WebSocket.new(env, nil)
+      env = Rack::MockRequest.env_for(
+        "/",
+        "HTTP_HOST" => "localhost",
+        "HTTP_CONNECTION" => "Upgrade",
+        "HTTP_UPGRADE" => "websocket",
 
-    expect(EventMachine.reactor_running?).to be(true)
-    expect(ws.rack_response).to eq([ -1, {}, [] ])
-  end
+        "rack.hijack" => rack_hijack_proc,
+        "rack.hijack_io" => Socket.new(:UNIX, :STREAM)
+      )
+      ws = Faye::WebSocket.new(env, nil)
 
-  it "can handle the reactor stopping during rack hijack" do
-    expect(EventMachine.reactor_running?).to be(false)
-
-    # The "rack.hijack" callback is called from RackStream#hijack_rack_socket,
-    # so we'll use it here as a timely hook to cause the next EM run loop to
-    # stop the reactor - but not before RackStream#hijack_rack_socket has
-    # scheduled its own work for the next EM tick.
-    hijack_proc = ->() do
       expect(EventMachine.reactor_running?).to be(true)
-
-      EventMachine.next_tick do
-        raise "error"
-      end
+      expect(ws.rack_response).to eq([ -1, {}, [] ])
     end
 
-    env = Rack::MockRequest.env_for(
-      "/",
-      "HTTP_HOST" => "localhost",
-      "HTTP_CONNECTION" => "Upgrade",
-      "HTTP_UPGRADE" => "websocket",
+    it "can handle the reactor stopping during rack hijack" do
+      # The "rack.hijack" callback is called from RackStream#hijack_rack_socket,
+      # so we'll use it here as a timely hook to cause the next EM run loop to
+      # stop the reactor - but not before RackStream#hijack_rack_socket has
+      # scheduled its own work for the next EM tick.
+      rack_hijack_proc = ->() do
+        expect(EventMachine.reactor_running?).to be(true)
 
-      "rack.hijack" => hijack_proc,
-      "rack.hijack_io" => Socket.new(:UNIX, :STREAM)
-    )
+        EventMachine.next_tick do
+          raise "error"
+        end
+      end
 
-    Timeout.timeout(1, Timeout::Error) do
-      Faye::WebSocket.new(env, nil)
+      env = Rack::MockRequest.env_for(
+        "/",
+        "HTTP_HOST" => "localhost",
+        "HTTP_CONNECTION" => "Upgrade",
+        "HTTP_UPGRADE" => "websocket",
+
+        "rack.hijack" => rack_hijack_proc,
+        "rack.hijack_io" => Socket.new(:UNIX, :STREAM)
+      )
+
+      # Wait one second longer than the 10 second rack hijack attach timeout
+      Timeout.timeout(11, Timeout::Error) do
+        Faye::WebSocket.new(env, nil)
+      end
+
+      expect(EventMachine.reactor_running?).to be(false)
     end
   end
 end

--- a/spec/faye/websocket_spec.rb
+++ b/spec/faye/websocket_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "socket"
 
 describe Faye::WebSocket do
   it "can start the reactor" do
@@ -14,5 +15,35 @@ describe Faye::WebSocket do
 
     expect(EventMachine.reactor_running?).to be(true)
     expect(ws.rack_response).to eq([ -1, {}, [] ])
+  end
+
+  it "can handle the reactor stopping during rack hijack" do
+    expect(EventMachine.reactor_running?).to be(false)
+
+    # The "rack.hijack" callback is called from RackStream#hijack_rack_socket,
+    # so we'll use it here as a timely hook to cause the next EM run loop to
+    # stop the reactor - but not before RackStream#hijack_rack_socket has
+    # scheduled its own work for the next EM tick.
+    hijack_proc = ->() do
+      expect(EventMachine.reactor_running?).to be(true)
+
+      EventMachine.next_tick do
+        raise "error"
+      end
+    end
+
+    env = Rack::MockRequest.env_for(
+      "/",
+      "HTTP_HOST" => "localhost",
+      "HTTP_CONNECTION" => "Upgrade",
+      "HTTP_UPGRADE" => "websocket",
+
+      "rack.hijack" => hijack_proc,
+      "rack.hijack_io" => Socket.new(:UNIX, :STREAM)
+    )
+
+    Timeout.timeout(1, Timeout::Error) do
+      Faye::WebSocket.new(env, nil)
+    end
   end
 end

--- a/spec/faye/websocket_spec.rb
+++ b/spec/faye/websocket_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Faye::WebSocket do
+  it "can start the reactor" do
+    expect(EventMachine.reactor_running?).to be(false)
+
+    env = Rack::MockRequest.env_for(
+      "/",
+      "HTTP_HOST" => "localhost",
+      "HTTP_CONNECTION" => "Upgrade",
+      "HTTP_UPGRADE" => "websocket"
+    )
+    ws = Faye::WebSocket.new(env, nil)
+
+    expect(EventMachine.reactor_running?).to be(true)
+    expect(ws.rack_response).to eq([ -1, {}, [] ])
+  end
+end


### PR DESCRIPTION
Addressing the issue described in #105, this adds a timeout to the rack hijack process to handle the reactor stopping while the calling thread is waiting on the reactor thread. 

The reactor can stop if an unhandled exception occurs on the reactor thread. This is problematic when it happens prior to `RackStream#hijack_rack_socket` attaching to the rack hijack socket, but _after_ `RackStream#hijack_rack_socket` has checked that the reactor is running in the calling thread. In the test I've included, this is contrived by piggybacking on the rack hijack callback proc to schedule an unhandled exception with the right timing. In the wild, an example of this is manifested by a high concurrency process (e.g. a passenger instance) with many em-http-request callbacks scheduled, where one callback raises an unhandled exception at the right time. 

The original result of the reactor stopping was an infinite wait in the calling thread - in the case of passenger, this would block the passenger instance (including all other threads if the instance was handling requests concurrently) indefinitely, eventually resulting in resource exhaustion.

---

Some questions/thoughts about these changes:

- I'm not very familiar with rspec, so please let me know if there's a more idiomatic way to structure the specs.

- I've defaulted to a 10 second timeout. Should this be a configurable duration? Perhaps the default should match the current behavior (no limit)?
