### PR TITLE
Fix blocking write issue by using EM::Connection instead

### DIFF
--- a/lib/faye/rack_stream.rb
+++ b/lib/faye/rack_stream.rb
@@ -91,6 +91,7 @@ module Faye
     end
 
     def write(data)
+      return @rack_hijack_io_reader.send_data(data) if @rack_hijack_io_reader
       return @rack_hijack_io.write(data) if @rack_hijack_io
       return @stream_send.call(data) if @stream_send
     rescue => e


### PR DESCRIPTION
Hi @jcoglan 

Long time no see ☺

Ok here's a simple fix a big issue we've been suffering for months now, and which took us a couple months to diagnose. Basically `faye-websocket` is not EM friendly because it uses low level blocking socket `write` instead of `EM::Connection#send_data` so it doesn't use the event loop for sending and this can result in very long lock (in case of slow client for example) blocking the event loop and thus killing the entire faye-server for every other client connected to it (for up to 60s in our case, that probably depends on default socket timeouts). We had this issue randomly in production for months and had to get some periodic stacktrace to be able to understand where and why it was blocked.

Better than an long explanation I compiled for you a small reproduction repo with script and explanations on how to reproduce the issue locally: https://github.com/dimelo/faye-websocket-slow-client-lock

The fix I suggest is quite simple: use `EM::Connection#send_data` (which uses the event loop) instead of `TCPSocket#write`. This fix passes by reproduction case, it passes `faye-websocket` tests, and has been used in our production (about 2000 msgs/sec) for 2 weeks. It has been working very well, no more random blocking of the faye server processes \o/

Let me know if you have any question!