### PR TITLE
binary frames are in exactly 1 byte-sized Integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Both the server- and client-side `WebSocket` objects support the following API:
   Event has no attributes.
 - **`on(:message) { |event| }`** fires when the socket receives a message. Event
   has one attribute, **`data`**, which is either a `String` (for text frames) or
-  an `Array` of byte-sized integers (for binary frames).
+  an `Array` of 1 byte-sized integers (for binary frames).
 - **`on(:error) { |event| }`** fires when there is a protocol error due to bad
   data sent by the other peer. This event is purely informational, you do not
   need to implement error recovery.


### PR DESCRIPTION
I recently dealt with this issue, as I was not a close enough reader of the README to realize that the description:

```
... or an `Array` of byte-sized integers (for binary frames)
```

comes to exclusively limit it to 1 byte-size integer (8 bits). I was working with 16-bit audio data and I couldn't understand why it was sounding so garbled, until a colleague and I re-read this README and understood the exclusivity of the statement. The addition of the `1` will make it clearer for future readers like me.