### PR TITLE
Implement SSL certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,38 @@ is an optional hash containing any of these keys:
   These are passed along to EventMachine and you can find
   [more details here](http://rubydoc.info/gems/eventmachine/EventMachine%2FConnection%3Astart_tls)
 
+### Secure sockets
+
+Starting with version 0.11.0, `Faye::WebSocket::Client` will verify the server
+certificate for `wss` connections. This is not the default behaviour for
+EventMachine's TLS interface, and so our defaults for the `:tls` option are a
+little different.
+
+First, `:verify_peer` is enabled by default. Our implementation checks that the
+chain of certificates sent by the server is trusted by your root certificates,
+and that the final certificate's hostname matches the hostname in the request
+URL.
+
+By default, we use your system's root certificate store by invoking
+`OpenSSL::X509::Store#set_default_paths`. If you want to use a different set of
+root certificates, you can pass them via the `:root_cert_file` option, which
+takes a path or an array of paths to the certificates you want to use.
+
+```ruby
+ws = Faye::WebSocket::Client.new('wss://example.com/', [], :tls => {
+  :root_cert_file => ['path/to/certificate.pem']
+})
+```
+
+If you want to switch off certificate verification altogether, then set
+`:verify_peer` to `false`.
+
+```ruby
+ws = Faye::WebSocket::Client.new('wss://example.com/', [], :tls => {
+  :verify_peer => false
+})
+```
+
 ## WebSocket API
 
 Both the server- and client-side `WebSocket` objects support the following API:

--- a/examples/client.rb
+++ b/examples/client.rb
@@ -6,9 +6,11 @@ require 'permessage_deflate'
 EM.run {
   url   = ARGV[0]
   proxy = ARGV[1]
+  ca    = File.expand_path('../../spec/server.crt', __FILE__)
 
   ws = Faye::WebSocket::Client.new(url, [],
     :proxy      => { :origin => proxy, :headers => { 'User-Agent' => 'Echo' } },
+    :tls        => { :root_cert_file => ca },
     :headers    => { 'Origin' => 'http://faye.jcoglan.com' },
     :extensions => [PermessageDeflate]
   )

--- a/lib/faye/websocket.rb
+++ b/lib/faye/websocket.rb
@@ -17,9 +17,10 @@ module Faye
   class WebSocket
     root = File.expand_path('../websocket', __FILE__)
 
-    autoload :Adapter, root + '/adapter'
-    autoload :API,     root + '/api'
-    autoload :Client,  root + '/client'
+    autoload :Adapter,      root + '/adapter'
+    autoload :API,          root + '/api'
+    autoload :Client,       root + '/client'
+    autoload :SslVerifier,  root + '/ssl_verifier'
 
     ADAPTERS = {
       'goliath'  => :Goliath,

--- a/lib/faye/websocket/ssl_verifier.rb
+++ b/lib/faye/websocket/ssl_verifier.rb
@@ -1,0 +1,89 @@
+# This code is based on the implementation in Faraday:
+#
+#     https://github.com/lostisland/faraday/blob/v1.0.1/lib/faraday/adapter/em_http_ssl_patch.rb
+#
+# Faraday is published under the MIT license as detailed here:
+#
+#     https://github.com/lostisland/faraday/blob/v1.0.1/LICENSE.md
+#
+# Copyright (c) 2009-2019 Rick Olson, Zack Hobson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+require 'openssl'
+
+module Faye
+  class WebSocket
+
+    SSLError = Class.new(OpenSSL::SSL::SSLError)
+
+    class SslVerifier
+      def initialize(hostname, ssl_opts)
+        @hostname   = hostname
+        @ssl_opts   = ssl_opts
+        @cert_store = OpenSSL::X509::Store.new
+
+        if root = @ssl_opts[:root_cert_file]
+          [root].flatten.each { |ca_path| @cert_store.add_file(ca_path) }
+        else
+          @cert_store.set_default_paths
+        end
+      end
+
+      def ssl_verify_peer(cert_text)
+        return true unless should_verify?
+
+        certificate = parse_cert(cert_text)
+        return false unless certificate
+
+        unless @cert_store.verify(certificate)
+          raise SSLError, "Unable to verify the server certificate for '#{ @hostname }'"
+        end
+
+        store_cert(certificate)
+        @last_cert = certificate
+
+        true
+      end
+
+      def ssl_handshake_completed
+        return unless should_verify?
+
+        unless identity_verified?
+          raise SSLError, "Host '#{ @hostname }' does not match the server certificate"
+        end
+      end
+
+    private
+
+      def should_verify?
+        @ssl_opts[:verify_peer] != false
+      end
+
+      def parse_cert(cert_text)
+        OpenSSL::X509::Certificate.new(cert_text)
+      rescue OpenSSL::X509::CertificateError
+        nil
+      end
+
+      def store_cert(certificate)
+        @cert_store.add_cert(certificate)
+      rescue OpenSSL::X509::StoreError => error
+        raise error unless error.message == 'cert already in hash table'
+      end
+
+      def identity_verified?
+        @last_cert and OpenSSL::SSL.verify_certificate_identity(@last_cert, @hostname)
+      end
+    end
+
+  end
+end

--- a/spec/faye/websocket/client_spec.rb
+++ b/spec/faye/websocket/client_spec.rb
@@ -39,14 +39,14 @@ WebSocketSteps = RSpec::EM.async_steps do
       end
     end
 
-    @ws = Faye::WebSocket::Client.new(url, protocols, :proxy => { :origin => proxy_url })
+    @ws = Faye::WebSocket::Client.new(url, protocols, :proxy => { :origin => proxy_url }, :tls => tls_options)
 
     @ws.on(:open) { |e| resume.call(true) }
     @ws.onclose = lambda { |e| resume.call(false) }
   end
 
   def open_socket_and_close_it_fast(url, protocols, &callback)
-    @ws = Faye::WebSocket::Client.new(url, protocols)
+    @ws = Faye::WebSocket::Client.new(url, protocols, :tls => tls_options)
 
     @ws.on(:open) { |e| @open = @ever_opened = true }
     @ws.onclose = lambda { |e| @open = false }
@@ -129,6 +129,10 @@ describe Faye::WebSocket::Client do
   let(:plain_text_url) { "ws://#{ localhost }:#{ port }/" }
   let(:wrong_url)      { "ws://#{ localhost }:9999/" }
   let(:secure_url)     { "wss://#{ localhost }:#{ port }/" }
+
+  let :tls_options do
+    { :root_cert_file => File.expand_path('../../../server.crt', __FILE__) }
+  end
 
   shared_examples_for "socket client" do
     before do


### PR DESCRIPTION
[EventMachine][em] supports making TCP connections via the
[`EM.connect`][em-connect] method. Once the connection is established, the
client can initiate a TLS session over the socket by calling
[`EM::Connection#start_tls`][em-start-tls]. This method _does not_ verify the
server's identity by default, but it does accept an option named `verify_peer`.
If this is set, the connection will invoke
[`EM::Connection#ssl_verify_peer`][em-verify-peer], a method supplied by the
caller which performs certificate validation. That is, EventMachine does not
implement such a validation routine itself; it requires the caller to supply
one.

This pull request implements such a validation routine using the OpenSSL module.
This implementation is derived from the one [in Faraday][faraday-patch], which
was [adopted by em-http-request][em-pr].

It changes the functionality of faye-websocket as follows:

- The caller can set the option `tls.verify_peer`, which defaults to `true`
- The caller can set the option `tls.cert_authority_file`, a path to a file
  containing a set of certificate authorities to use in place of the system
  default set
- When connecting through a proxy, only verifying the origin server's identity
  is supported

We have considered that enabling `verify_peer` by default may be a breaking
change, and considered two situations where this might apply:

- The client is not talking to the server it thinks it is, because verification
  is turned off and the client is being attacked
- The client is intentionally talking to a server that the system CAs would not
  recognised, for example a server with a self-signed cert

We regard the first situation as a bug, not behaviour we intentionally support.
It's what this PR is designed to fix. We regard the second situation as a
possibly-breaking change but give such clients a means to get back to a working
state, either by setting the `tls.cert_authority_file` file to point to their
server's certificate, or by switching off `tls.verify_peer`.

In copying over the implementation from Faraday I have kept the same calls to
OpenSSL in place, with the addition of calling `OpenSSL::X509::Store#add_file`
instead of `OpenSSL::X509::Store#set_default_paths` if `cert_authority_file` is
set. As in the Faraday implementation, I have split the functionality between
the `ssl_verify_peer` and `ssl_handshake_completed` callbacks. I am not
completely sure why this done, but my assumption is that as `ssl_verify_peer` is
called in turn with every certificate in the server's chain, its only job is to
check that each new cert can be verified by the certs already in the chain,
forming a chain of trust from the client's trusted certs all the way down the
server's list of certificates. When `ssl_handshake_completed` is called, we know
all the certificates have now been processed and we need to verify the hostname
from the last one the server sent. I'd like some feedback on whether this is
correct and my approach is valid.

There is also the bigger question that this code needs reviewing and
maintaining, and I am not an expert on SSL/TLS, X509, or anything else that's
relevant. I feel that this functionality should be baked into EventMachine, or
at least have a default implementation, rather than EventMachine's users having
to write their own sections of important security code. I would like to know how
risky it is in practice for us to own this code, and whether we should push for
another approach. For example, we could request that EventMachine implement this
functionality, or we could gather support for a shared library that implements
it, where that library could be used by faye-websocket, em-http-request, and
anything else using EventMachine's TLS support.

[em]: https://rubygems.org/gems/eventmachine
[em-connect]: https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine#connect-class_method
[em-start-tls]: https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection:start_tls
[em-verify-peer]: https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection:ssl_verify_peer

[faraday-patch]: https://github.com/lostisland/faraday/blob/v1.0.1/lib/faraday/adapter/em_http_ssl_patch.rb
[em-pr]: https://github.com/igrigorik/em-http-request/pull/340/files