### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+cache: bundler
+
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Would be interested to know why Travis caching hasn't been enabled in this repository. Thank you.
