### PR TITLE
Fix: openssl add cert error on ruby 3.1

### DIFF
--- a/lib/faye/websocket/ssl_verifier.rb
+++ b/lib/faye/websocket/ssl_verifier.rb
@@ -80,7 +80,7 @@ module Faye
       def store_cert(certificate)
         @cert_store.add_cert(certificate)
       rescue OpenSSL::X509::StoreError => error
-        raise error unless error.message == 'cert already in hash table'
+        raise error unless error.message =~ /cert already in hash table/
       end
 
       def identity_verified?


### PR DESCRIPTION
On ruby 3.1 the error now reads: 'X509_STORE_add_cert: cert already in hash table'

So we need to match more than just the exact string