### PR TITLE
pass :binary_data_format option to driver

### DIFF
--- a/lib/faye/websocket/api.rb
+++ b/lib/faye/websocket/api.rb
@@ -22,7 +22,9 @@ module Faye
       def initialize(options = {})
         @ready_state = CONNECTING
         super()
-        ::WebSocket::Driver.validate_options(options, [:headers, :extensions, :max_length, :ping, :proxy, :tls])
+        ::WebSocket::Driver.validate_options(options, [
+          :headers, :extensions, :max_length, :ping, :proxy, :tls, :binary_data_format
+        ])
 
         @driver = yield
 

--- a/lib/faye/websocket/client.rb
+++ b/lib/faye/websocket/client.rb
@@ -14,7 +14,13 @@ module Faye
 
       def initialize(url, protocols = nil, options = {})
         @url = url
-        super(options) { ::WebSocket::Driver.client(self, :max_length => options[:max_length], :protocols => protocols) }
+        super(options) {
+          ::WebSocket::Driver.client(self,
+            :max_length => options[:max_length],
+            :protocols => protocols,
+            :binary_data_format => options[:binary_data_format]
+          )
+        }
 
         proxy       = options.fetch(:proxy, {})
         @endpoint   = URI.parse(proxy[:origin] || @url)


### PR DESCRIPTION
This is the second part of the PR for `websocket-driver` here https://github.com/faye/websocket-driver-ruby/pull/95.

This just makes `Faye::Websocket::Client` accept the `:binary_data_format` option and pass it to the `Driver`.